### PR TITLE
feat(cli.js): add rawLeaves option defaults to true to create consistent CID with go-ipfs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,10 +11,14 @@ const cli = meow(`
     # get the cid v0 for data from stdin
     $ echo "hello world" | ipfs-only-hash --cid-version 0
 `, {
+  booleanDefault: undefined,
   flags: {
     cidVersion: {
       type: 'number',
       default: 1
+    },
+    rawLeaves: {
+      type: 'boolean',
     }
   }
 })
@@ -24,7 +28,9 @@ async function main (cli) {
   if (cli.input[0]) {
     stream = fs.createReadStream(cli.input[0])
   }
-  const hash = await Hash.of(stream, { cidVersion: cli.flags.cidVersion })
+  const cidVersion = cli.flags.cidVersion
+  const rawLeaves = (cidVersion === 1 && cli.flags.rawLeaves === undefined) ? true : cli.flags.rawLeaves;
+  const hash = await Hash.of(stream, { cidVersion, rawLeaves })
   console.log(hash)
 }
 


### PR DESCRIPTION
### Problem to address
When using the official go-ipfs CLI or API, setting CID to v1 would set the `--raw-leaves` option defaults to `true`, as discussed in https://github.com/ipfs/go-ipfs/issues/4188.
It seems to me it would be better if the `ipfs-only-hash` CLI could have the same behavior as the current official CLI: the `--raw-leaves` option be defaulted to `true` if using v1 CID while it could still be overridden by specifying `--raw-leaves false`.

### Breaking Change
Set rawLeaves options to true by default, so the default CIDv1 created will be different.